### PR TITLE
Added a new helper method to update the end-effector link for control

### DIFF
--- a/arm_commander/commander_moveit.py
+++ b/arm_commander/commander_moveit.py
@@ -551,6 +551,23 @@ class GeneralCommander():
         :type tol_list: list
         """
         self.move_group.set_goal_tolerance(tol_list) 
+
+    # set the move group end effector link
+    def set_end_effector_link(self, new_link:str = None):
+        if new_link is None:
+            rospy.logwarn(f"Provided link is NONE. Exiting unchanged")
+            return
+
+        # Debugging output for current end-effector 
+        rospy.loginfo(f"Current end effector configured: {self.move_group.get_end_effector_link()}")
+
+        # Set the new link (if valid)
+        # NOTE: error's out if link is invalid
+        # TODO: update to check a list of valid links prior to updating
+        self.move_group.set_end_effector_link(new_link)
+        self.END_EFFECTOR_LINK = self.move_group.get_end_effector_link()
+        
+        rospy.loginfo(f"Updated end-effector link is: {self.END_EFFECTOR_LINK}")
     
     # return a list of current joint, position and orientation goal tolerances
     def get_goal_tolerance(self) -> list:


### PR DESCRIPTION
A single method has been added called **set_end_effector_link**, which has a default argument of **None** (causing exit if not specified - retaining the default link without any change). If not None, calls the move_group.set_end_effector_link method and updates the arm_commander self.END_EFFECTOR_LINK variable. 

Please note functional tests below:
- Confirmed updated link for end-effector works (i.e., move to pose reflected on changed link)
- Confirmed empty request and exit (without change). Debugging message as ROS warn log level
- Tested non-existent link input. Currently terminates the node as TF fails to lookup. Future work here needs to get a list of valid links in tree and confirm prior to setting. TODO added in code as reference.